### PR TITLE
Update Fabric extension - location and tag selection

### DIFF
--- a/extensions/fabric/CHANGELOG.md
+++ b/extensions/fabric/CHANGELOG.md
@@ -2,4 +2,10 @@
 
 ## [Initial Version] - 2025-03-28
 
-- Basic search and creation functionality
+- Basic search and creation functionality.
+
+## [Location and Tag Selection] - 2025-03-28
+
+- Allow assignging existing tags, and create new ones, when saving an item.
+- Allow selecting location when saving an item.
+- Fallback icons are based on item type

--- a/extensions/fabric/CHANGELOG.md
+++ b/extensions/fabric/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Basic search and creation functionality.
 
-## [Location and Tag Selection] - 2025-03-28
+## [Location and Tag Selection] - {PR_MERGE_DATE}
 
-- Allow assignging existing tags, and create new ones, when saving an item.
+- Allow assigning existing tags, and create new ones, when saving an item.
 - Allow selecting location when saving an item.
-- Fallback icons are based on item type
+- Fallback icons are based on item type.

--- a/extensions/fabric/CHANGELOG.md
+++ b/extensions/fabric/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Fabric Changelog
 
-## [Initial Version] - 2025-03-28
-
-- Basic search and creation functionality.
-
 ## [Location and Tag Selection] - 2025-05-28
 
 - Allow assigning existing tags, and create new ones, when saving an item.
 - Allow selecting location when saving an item.
 - Fallback icons are based on item type.
+
+## [Initial Version] - 2025-03-28
+
+- Basic search and creation functionality.

--- a/extensions/fabric/CHANGELOG.md
+++ b/extensions/fabric/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Basic search and creation functionality.
 
-## [Location and Tag Selection] - {PR_MERGE_DATE}
+## [Location and Tag Selection] - 2025-05-28
 
 - Allow assigning existing tags, and create new ones, when saving an item.
 - Allow selecting location when saving an item.

--- a/extensions/fabric/src/api/fabricClient.ts
+++ b/extensions/fabric/src/api/fabricClient.ts
@@ -148,7 +148,7 @@ class FabricClient {
   private async request({ path, method, body, expectedStatusCodes = [200] }: APIRequestOptions) {
     const { token } = await getAccessToken();
     const response = await fetch(`${this.endpoint}${path}`, {
-      method: method || 'GET',
+      method: method || "GET",
       headers: {
         "Content-Type": body instanceof Buffer ? "application/octet-stream" : "application/json",
         Authorization: `Bearer ${token}`,
@@ -173,9 +173,7 @@ class FabricClient {
   }
 
   private prepareCreationTags(tagsExisting?: string[], tagsNew?: string): CreationTags {
-    const tags: CreationTags = tagsExisting?.length
-      ? tagsExisting.map((tag) => ({ id: tag }))
-      : [];
+    const tags: CreationTags = tagsExisting?.length ? tagsExisting.map((tag) => ({ id: tag })) : [];
     if (tagsNew) {
       tags.push(
         ...this.parseTags(tagsNew).map((tag) => ({
@@ -195,7 +193,7 @@ class FabricClient {
         ...(query.text && { name: query.text }),
         ...(query.kind && { kind: [query.kind] }),
         order: {
-          property: 'name',
+          property: "name",
         },
       }),
       expectedStatusCodes: [200],

--- a/extensions/fabric/src/api/fabricClient.ts
+++ b/extensions/fabric/src/api/fabricClient.ts
@@ -19,7 +19,7 @@ type JSONValue = string | number | boolean | null | JSONObject | JSONArray;
 
 type APIRequestOptions = {
   path: string;
-  method: string;
+  method?: string;
   body?: Buffer | JSONValue;
   expectedStatusCodes?: number[];
 };
@@ -43,6 +43,10 @@ export interface Resource {
   thumbnail?: {
     sm: string;
   };
+  parent: {
+    id: string;
+    name: string;
+  } | null;
 }
 
 export enum Kind {
@@ -58,19 +62,37 @@ export enum Kind {
 }
 
 export interface SearchQuery {
-  text: string;
+  text?: string;
   kind?: Kind;
+  includeRoots?: boolean;
+  order?: {
+    property: string;
+    direction?: "ASC" | "DESC";
+  };
 }
 
 export interface CreateNotepadParams {
   name: string;
   content: string;
+  tagsExisting?: string[];
+  tagsNew?: string;
+  parentId: string;
 }
 
 export interface CreateBookmarkParams {
   url: string;
   comment: string;
+  tagsExisting?: string[];
+  tagsNew?: string;
+  parentId: string;
 }
+
+export interface Tag {
+  id: string;
+  name: string;
+}
+
+type CreationTags = ({ id: string } | { name: string })[];
 
 /**
  * Given a object it tries to transform it into a JSONValue that can be sent to
@@ -126,7 +148,7 @@ class FabricClient {
   private async request({ path, method, body, expectedStatusCodes = [200] }: APIRequestOptions) {
     const { token } = await getAccessToken();
     const response = await fetch(`${this.endpoint}${path}`, {
-      method,
+      method: method || 'GET',
       headers: {
         "Content-Type": body instanceof Buffer ? "application/octet-stream" : "application/json",
         Authorization: `Bearer ${token}`,
@@ -143,19 +165,59 @@ class FabricClient {
     return response;
   }
 
+  private parseTags(tags: string): string[] {
+    return tags
+      .split(/[\n#,]+/)
+      .map((tag) => tag.trim())
+      .filter((tag) => !!tag);
+  }
+
+  private prepareCreationTags(tagsExisting?: string[], tagsNew?: string): CreationTags {
+    const tags: CreationTags = tagsExisting?.length
+      ? tagsExisting.map((tag) => ({ id: tag }))
+      : [];
+    if (tagsNew) {
+      tags.push(
+        ...this.parseTags(tagsNew).map((tag) => ({
+          name: tag,
+        })),
+      );
+    }
+    return tags;
+  }
+
   async listResources(query: SearchQuery): Promise<Resource[]> {
     const response = await this.request({
       path: "/resources/filter",
       method: "POST",
       body: transformToJSONValue({
-        name: query.text,
+        includeRoots: query.includeRoots || false,
+        ...(query.text && { name: query.text }),
         ...(query.kind && { kind: [query.kind] }),
+        order: {
+          property: 'name',
+        },
       }),
       expectedStatusCodes: [200],
     });
 
     const body = (await response.json()) as { resources: Resource[] };
     return body.resources;
+  }
+
+  async listTags(): Promise<Tag[]> {
+    const response = await this.request({
+      path: "/tags",
+      expectedStatusCodes: [200],
+    });
+
+    const body = (await response.json()) as {
+      count: number;
+      data: {
+        tags: Tag[];
+      };
+    };
+    return body.data.tags;
   }
 
   async searchResources(query: SearchQuery): Promise<Resource[]> {
@@ -182,20 +244,21 @@ class FabricClient {
     return body.hits;
   }
 
-  async createNotepad({ name, content }: CreateNotepadParams) {
+  async createNotepad({ name, content, tagsExisting, tagsNew, parentId }: CreateNotepadParams) {
     await this.request({
       path: "/notepads",
       method: "POST",
       body: transformToJSONValue({
         ...(name && { name }),
-        parentId: "@alias::inbox",
         ydoc: Array.from(await this.createYDocFromMarkdown(content)),
+        parentId,
+        tags: this.prepareCreationTags(tagsExisting, tagsNew),
       }),
       expectedStatusCodes: [201],
     });
   }
 
-  async createBookmark({ url, comment }: CreateBookmarkParams) {
+  async createBookmark({ url, comment, tagsExisting, tagsNew, parentId }: CreateBookmarkParams) {
     await this.request({
       path: "/bookmarks",
       method: "POST",
@@ -206,7 +269,8 @@ class FabricClient {
             content: comment,
           },
         }),
-        parentId: "@alias::inbox",
+        parentId,
+        tags: this.prepareCreationTags(tagsExisting, tagsNew),
       }),
       expectedStatusCodes: [201],
     });

--- a/extensions/fabric/src/components/CreationMetadata.tsx
+++ b/extensions/fabric/src/components/CreationMetadata.tsx
@@ -1,0 +1,53 @@
+import { Form } from "@raycast/api";
+
+import { useTags } from "../hooks/useTags";
+import { useFolders } from "../hooks/useFolders";
+
+interface MetadataValues extends Form.Values {
+  tagsNew: string;
+  tagsExisting: string[];
+  parentId: string;
+};
+
+type ItemProps<T extends MetadataValues> = {
+  [id in keyof T]: Partial<Form.ItemProps<T[id]>> & {
+    id: string;
+  };
+};
+
+type Params<T extends MetadataValues> = {
+  itemProps: ItemProps<T>;
+};
+
+export function CreationMetadata<T extends MetadataValues>(params: Params<T>) {
+  const tags = useTags();
+  const folders = useFolders();
+
+  return (
+    <>
+      <Form.Separator />
+      <Form.Dropdown title="Folder" placeholder="Select a folder" {...params.itemProps.parentId}>
+        <Form.Dropdown.Item value="@alias::inbox" title="Inbox" icon="📥" />
+        {folders.map((folder) => (
+          <Form.Dropdown.Item
+            key={folder.id}
+            value={folder.id}
+            title={folder.name}
+            icon={folder.parent ? "📁" : "🗂️"}
+          />
+        ))}
+      </Form.Dropdown>
+      <Form.TagPicker title="Existing Tags" placeholder="Assign existing tags" {...params.itemProps.tagsExisting}>
+        {tags.map((tag) => (
+          <Form.TagPicker.Item key={tag.id} value={tag.id} title={tag.name} />
+        ))}
+      </Form.TagPicker>
+      <Form.TextField
+        title="New Tags"
+        placeholder="Create new tags"
+        info="Comma separated list."
+        {...params.itemProps.tagsNew}
+      />
+    </>
+  );
+}

--- a/extensions/fabric/src/components/CreationMetadata.tsx
+++ b/extensions/fabric/src/components/CreationMetadata.tsx
@@ -20,13 +20,18 @@ type Params<T extends MetadataValues> = {
 };
 
 export function CreationMetadata<T extends MetadataValues>(params: Params<T>) {
-  const tags = useTags();
-  const folders = useFolders();
+  const { tags } = useTags();
+  const { folders, isLoading: foldersLoading } = useFolders();
 
   return (
     <>
       <Form.Separator />
-      <Form.Dropdown title="Folder" placeholder="Select a folder" {...params.itemProps.parentId}>
+      <Form.Dropdown
+        title="Folder"
+        placeholder="Select a folder"
+        isLoading={foldersLoading}
+        {...params.itemProps.parentId}
+      >
         <Form.Dropdown.Item value="@alias::inbox" title="Inbox" icon="📥" />
         {folders.map((folder) => (
           <Form.Dropdown.Item

--- a/extensions/fabric/src/components/CreationMetadata.tsx
+++ b/extensions/fabric/src/components/CreationMetadata.tsx
@@ -7,7 +7,7 @@ interface MetadataValues extends Form.Values {
   tagsNew: string;
   tagsExisting: string[];
   parentId: string;
-};
+}
 
 type ItemProps<T extends MetadataValues> = {
   [id in keyof T]: Partial<Form.ItemProps<T[id]>> & {

--- a/extensions/fabric/src/config.ts
+++ b/extensions/fabric/src/config.ts
@@ -1,4 +1,3 @@
 export const URL_APP = "https://fabric.so";
 export const URL_API = "https://api.fabric.so";
 export const CLIENT_ID = "6a0fc040-fecc-47f0-9510-b30b3c5a1d68";
-export const ICON_FALLBACK = "https://fabric.so/favicon.ico";

--- a/extensions/fabric/src/create-bookmark.tsx
+++ b/extensions/fabric/src/create-bookmark.tsx
@@ -2,8 +2,7 @@ import { Form, ActionPanel, Action, showToast, Toast } from "@raycast/api";
 import { useForm, FormValidation, withAccessToken } from "@raycast/utils";
 
 import { CreateBookmarkParams, getFabricClient, oauthService } from "./api/fabricClient";
-import { useTags } from "./hooks/useTags";
-import { useFolders } from "./hooks/useFolders";
+import { CreationMetadata } from './components/CreationMetadata';
 
 type CreationValues = {
   url: string;
@@ -14,9 +13,6 @@ type CreationValues = {
 };
 
 function CreateBookmark() {
-  const tags = useTags();
-  const folders = useFolders();
-
   const { handleSubmit, itemProps, reset } = useForm<CreationValues>({
     async onSubmit(values: CreateBookmarkParams) {
       const toast = await showToast({
@@ -55,29 +51,7 @@ function CreateBookmark() {
     >
       <Form.TextField title="Link" placeholder="Type or paste a link..." {...itemProps.url} />
       <Form.TextArea title="Comment" placeholder="Say something about it (optional)" {...itemProps.comment} />
-      <Form.Separator />
-      <Form.Dropdown title="Folder" placeholder="Select a folder" {...itemProps.parentId}>
-        <Form.Dropdown.Item value="@alias::inbox" title="Inbox" icon="📥" />
-        {folders.map((folder) => (
-          <Form.Dropdown.Item
-            key={folder.id}
-            value={folder.id}
-            title={folder.name}
-            icon={folder.parent ? "📁" : "🗂️"}
-          />
-        ))}
-      </Form.Dropdown>
-      <Form.TagPicker title="Existing Tags" placeholder="Assign existing tags" {...itemProps.tagsExisting}>
-        {tags.map((tag) => (
-          <Form.TagPicker.Item key={tag.id} value={tag.id} title={tag.name} />
-        ))}
-      </Form.TagPicker>
-      <Form.TextField
-        title="New Tags"
-        placeholder="Create new tags"
-        info="Comma separated list."
-        {...itemProps.tagsNew}
-      />
+      <CreationMetadata<CreationValues> itemProps={itemProps} />
     </Form>
   );
 }

--- a/extensions/fabric/src/create-bookmark.tsx
+++ b/extensions/fabric/src/create-bookmark.tsx
@@ -2,7 +2,7 @@ import { Form, ActionPanel, Action, showToast, Toast } from "@raycast/api";
 import { useForm, FormValidation, withAccessToken } from "@raycast/utils";
 
 import { CreateBookmarkParams, getFabricClient, oauthService } from "./api/fabricClient";
-import { CreationMetadata } from './components/CreationMetadata';
+import { CreationMetadata } from "./components/CreationMetadata";
 
 type CreationValues = {
   url: string;

--- a/extensions/fabric/src/create-bookmark.tsx
+++ b/extensions/fabric/src/create-bookmark.tsx
@@ -2,13 +2,21 @@ import { Form, ActionPanel, Action, showToast, Toast } from "@raycast/api";
 import { useForm, FormValidation, withAccessToken } from "@raycast/utils";
 
 import { CreateBookmarkParams, getFabricClient, oauthService } from "./api/fabricClient";
+import { useTags } from "./hooks/useTags";
+import { useFolders } from "./hooks/useFolders";
 
 type CreationValues = {
   url: string;
   comment: string;
+  tagsNew: string;
+  tagsExisting: string[];
+  parentId: string;
 };
 
 function CreateBookmark() {
+  const tags = useTags();
+  const folders = useFolders();
+
   const { handleSubmit, itemProps, reset } = useForm<CreationValues>({
     async onSubmit(values: CreateBookmarkParams) {
       const toast = await showToast({
@@ -47,6 +55,29 @@ function CreateBookmark() {
     >
       <Form.TextField title="Link" placeholder="Type or paste a link..." {...itemProps.url} />
       <Form.TextArea title="Comment" placeholder="Say something about it (optional)" {...itemProps.comment} />
+      <Form.Separator />
+      <Form.Dropdown title="Folder" placeholder="Select a folder" {...itemProps.parentId}>
+        <Form.Dropdown.Item value="@alias::inbox" title="Inbox" icon="📥" />
+        {folders.map((folder) => (
+          <Form.Dropdown.Item
+            key={folder.id}
+            value={folder.id}
+            title={folder.name}
+            icon={folder.parent ? "📁" : "🗂️"}
+          />
+        ))}
+      </Form.Dropdown>
+      <Form.TagPicker title="Existing Tags" placeholder="Assign existing tags" {...itemProps.tagsExisting}>
+        {tags.map((tag) => (
+          <Form.TagPicker.Item key={tag.id} value={tag.id} title={tag.name} />
+        ))}
+      </Form.TagPicker>
+      <Form.TextField
+        title="New Tags"
+        placeholder="Create new tags"
+        info="Comma separated list."
+        {...itemProps.tagsNew}
+      />
     </Form>
   );
 }

--- a/extensions/fabric/src/create-notepad.tsx
+++ b/extensions/fabric/src/create-notepad.tsx
@@ -2,7 +2,7 @@ import { Form, ActionPanel, Action, showToast, Toast } from "@raycast/api";
 import { useForm, FormValidation, withAccessToken } from "@raycast/utils";
 
 import { CreateNotepadParams, getFabricClient, oauthService } from "./api/fabricClient";
-import { CreationMetadata } from './components/CreationMetadata';
+import { CreationMetadata } from "./components/CreationMetadata";
 
 type CreationValues = {
   name: string;

--- a/extensions/fabric/src/create-notepad.tsx
+++ b/extensions/fabric/src/create-notepad.tsx
@@ -2,13 +2,21 @@ import { Form, ActionPanel, Action, showToast, Toast } from "@raycast/api";
 import { useForm, FormValidation, withAccessToken } from "@raycast/utils";
 
 import { CreateNotepadParams, getFabricClient, oauthService } from "./api/fabricClient";
+import { useTags } from "./hooks/useTags";
+import { useFolders } from "./hooks/useFolders";
 
 type CreationValues = {
   name: string;
   content: string;
+  tagsNew: string;
+  tagsExisting: string[];
+  parentId: string;
 };
 
 function CreateNote() {
+  const tags = useTags();
+  const folders = useFolders();
+
   const { handleSubmit, itemProps, reset } = useForm<CreationValues>({
     async onSubmit(values: CreateNotepadParams) {
       const toast = await showToast({
@@ -23,6 +31,9 @@ function CreateNote() {
         reset({
           name: "",
           content: "",
+          tagsNew: "",
+          parentId: "@alias::inbox",
+          tagsExisting: [],
         });
 
         toast.style = Toast.Style.Success;
@@ -53,6 +64,29 @@ function CreateNote() {
         autoFocus={true}
         enableMarkdown={true}
         {...itemProps.content}
+      />
+      <Form.Separator />
+      <Form.Dropdown title="Folder" placeholder="Select a folder" {...itemProps.parentId}>
+        <Form.Dropdown.Item value="@alias::inbox" title="Inbox" icon="📥" />
+        {folders.map((folder) => (
+          <Form.Dropdown.Item
+            key={folder.id}
+            value={folder.id}
+            title={folder.name}
+            icon={folder.parent ? "📁" : "🗂️"}
+          />
+        ))}
+      </Form.Dropdown>
+      <Form.TagPicker title="Existing Tags" placeholder="Assign existing tags" {...itemProps.tagsExisting}>
+        {tags.map((tag) => (
+          <Form.TagPicker.Item key={tag.id} value={tag.id} title={tag.name} />
+        ))}
+      </Form.TagPicker>
+      <Form.TextField
+        title="New Tags"
+        placeholder="Create new tags"
+        info="Comma separated list."
+        {...itemProps.tagsNew}
       />
     </Form>
   );

--- a/extensions/fabric/src/create-notepad.tsx
+++ b/extensions/fabric/src/create-notepad.tsx
@@ -2,8 +2,7 @@ import { Form, ActionPanel, Action, showToast, Toast } from "@raycast/api";
 import { useForm, FormValidation, withAccessToken } from "@raycast/utils";
 
 import { CreateNotepadParams, getFabricClient, oauthService } from "./api/fabricClient";
-import { useTags } from "./hooks/useTags";
-import { useFolders } from "./hooks/useFolders";
+import { CreationMetadata } from './components/CreationMetadata';
 
 type CreationValues = {
   name: string;
@@ -14,9 +13,6 @@ type CreationValues = {
 };
 
 function CreateNote() {
-  const tags = useTags();
-  const folders = useFolders();
-
   const { handleSubmit, itemProps, reset } = useForm<CreationValues>({
     async onSubmit(values: CreateNotepadParams) {
       const toast = await showToast({
@@ -65,29 +61,7 @@ function CreateNote() {
         enableMarkdown={true}
         {...itemProps.content}
       />
-      <Form.Separator />
-      <Form.Dropdown title="Folder" placeholder="Select a folder" {...itemProps.parentId}>
-        <Form.Dropdown.Item value="@alias::inbox" title="Inbox" icon="📥" />
-        {folders.map((folder) => (
-          <Form.Dropdown.Item
-            key={folder.id}
-            value={folder.id}
-            title={folder.name}
-            icon={folder.parent ? "📁" : "🗂️"}
-          />
-        ))}
-      </Form.Dropdown>
-      <Form.TagPicker title="Existing Tags" placeholder="Assign existing tags" {...itemProps.tagsExisting}>
-        {tags.map((tag) => (
-          <Form.TagPicker.Item key={tag.id} value={tag.id} title={tag.name} />
-        ))}
-      </Form.TagPicker>
-      <Form.TextField
-        title="New Tags"
-        placeholder="Create new tags"
-        info="Comma separated list."
-        {...itemProps.tagsNew}
-      />
+      <CreationMetadata<CreationValues> itemProps={itemProps} />
     </Form>
   );
 }

--- a/extensions/fabric/src/hooks/useFolders.ts
+++ b/extensions/fabric/src/hooks/useFolders.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from "react";
 import { showToast, Toast } from "@raycast/api";
 
 import { getFabricClient, Kind, Resource } from "../api/fabricClient";
@@ -15,7 +15,7 @@ export function useFolders() {
           kind: Kind.FOLDER,
           includeRoots: true,
           order: {
-            property: "name"
+            property: "name",
           },
         });
 

--- a/extensions/fabric/src/hooks/useFolders.ts
+++ b/extensions/fabric/src/hooks/useFolders.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+import { showToast, Toast } from "@raycast/api";
+
+import { getFabricClient, Kind, Resource } from "../api/fabricClient";
+
+export function useFolders() {
+  const [folders, setFolders] = useState<Resource[]>([]);
+
+  useEffect(() => {
+    const fetchFolders = async () => {
+      const fabricClient = getFabricClient();
+      try {
+        const foldersList = await fabricClient.listResources({
+          text: "",
+          kind: Kind.FOLDER,
+          includeRoots: true,
+          order: {
+            property: "name"
+          },
+        });
+
+        // Spaces should come on top, otherwise sort alphabetically
+        foldersList.sort((a, b) => {
+          if (!a.parent && !b.parent) return a.name.localeCompare(b.name);
+          if (!a.parent) return -1; // a has no parent, comes first
+          if (!b.parent) return 1; // b has no parent, comes first
+          return a.name.localeCompare(b.name); // both have parents, sort alphabetically
+        });
+
+        setFolders(foldersList);
+      } catch (error) {
+        showToast({
+          style: Toast.Style.Failure,
+          title: "Failed to fetch folders",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    };
+
+    fetchFolders();
+  }, []);
+
+  return folders;
+}

--- a/extensions/fabric/src/hooks/useFolders.ts
+++ b/extensions/fabric/src/hooks/useFolders.ts
@@ -1,13 +1,16 @@
 import { useState, useEffect } from "react";
-import { showToast, Toast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 
 import { getFabricClient, Kind, Resource } from "../api/fabricClient";
 
 export function useFolders() {
   const [folders, setFolders] = useState<Resource[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchFolders = async () => {
+      setIsLoading(true);
+
       const fabricClient = getFabricClient();
       try {
         const foldersList = await fabricClient.listResources({
@@ -29,16 +32,14 @@ export function useFolders() {
 
         setFolders(foldersList);
       } catch (error) {
-        showToast({
-          style: Toast.Style.Failure,
-          title: "Failed to fetch folders",
-          message: error instanceof Error ? error.message : "Unknown error",
-        });
+        showFailureToast(error, { title: "Failed to fetch folders" });
       }
+
+      setIsLoading(false);
     };
 
     fetchFolders();
   }, []);
 
-  return folders;
+  return { folders, isLoading };
 }

--- a/extensions/fabric/src/hooks/useTags.ts
+++ b/extensions/fabric/src/hooks/useTags.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from "react";
 import { showToast, Toast } from "@raycast/api";
 
 import { getFabricClient, Tag } from "../api/fabricClient";
@@ -25,4 +25,4 @@ export function useTags() {
   }, []);
 
   return tags;
-};
+}

--- a/extensions/fabric/src/hooks/useTags.ts
+++ b/extensions/fabric/src/hooks/useTags.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+import { showToast, Toast } from "@raycast/api";
+
+import { getFabricClient, Tag } from "../api/fabricClient";
+
+export function useTags() {
+  const [tags, setTags] = useState<Tag[]>([]);
+
+  useEffect(() => {
+    const fetchTags = async () => {
+      const fabricClient = getFabricClient();
+      try {
+        const tagsList = await fabricClient.listTags();
+        setTags(tagsList);
+      } catch (error) {
+        showToast({
+          style: Toast.Style.Failure,
+          title: "Failed to fetch tags",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    };
+
+    fetchTags();
+  }, []);
+
+  return tags;
+};

--- a/extensions/fabric/src/hooks/useTags.ts
+++ b/extensions/fabric/src/hooks/useTags.ts
@@ -1,28 +1,29 @@
 import { useState, useEffect } from "react";
-import { showToast, Toast } from "@raycast/api";
+import { showFailureToast } from "@raycast/utils";
 
 import { getFabricClient, Tag } from "../api/fabricClient";
 
 export function useTags() {
   const [tags, setTags] = useState<Tag[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchTags = async () => {
+      setIsLoading(true);
+
       const fabricClient = getFabricClient();
       try {
         const tagsList = await fabricClient.listTags();
         setTags(tagsList);
       } catch (error) {
-        showToast({
-          style: Toast.Style.Failure,
-          title: "Failed to fetch tags",
-          message: error instanceof Error ? error.message : "Unknown error",
-        });
+        showFailureToast(error, { title: "Failed to fetch tags" });
       }
+
+      setIsLoading(false);
     };
 
     fetchTags();
   }, []);
 
-  return tags;
+  return { tags, isLoading };
 }

--- a/extensions/fabric/src/search-fabric.tsx
+++ b/extensions/fabric/src/search-fabric.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ActionPanel, Action, Color, Image, List, showToast, Toast } from "@raycast/api";
+import { ActionPanel, Action, Image, List, showToast, Toast } from "@raycast/api";
 import { withAccessToken, showFailureToast } from "@raycast/utils";
 
 import { getFabricClient, Kind, Resource, SearchQuery, oauthService } from "./api/fabricClient";

--- a/extensions/fabric/src/search-fabric.tsx
+++ b/extensions/fabric/src/search-fabric.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
-import { ActionPanel, Action, List, showToast, Toast } from "@raycast/api";
+import { ActionPanel, Action, Color, Image, List, showToast, Toast } from "@raycast/api";
 import { withAccessToken, showFailureToast } from "@raycast/utils";
 
 import { getFabricClient, Kind, Resource, SearchQuery, oauthService } from "./api/fabricClient";
 import { getKindIcon, removeHtml } from "./utils";
-import { URL_APP, ICON_FALLBACK } from "./config";
+import { URL_APP } from "./config";
 
 const KINDS: [Kind, string][] = [
   [Kind.IMAGE, "Image"],
@@ -22,7 +22,7 @@ interface SearchResult {
   id: string;
   name: string;
   description: string;
-  icon: string;
+  icon: Image.ImageLike;
 }
 
 type SearchResponse =
@@ -61,7 +61,7 @@ const apiFilter = async (searchQuery: SearchQuery): Promise<SearchResponse> => {
       description = item.data.webpage?.description || "";
     }
 
-    let icon = ICON_FALLBACK;
+    let icon: Image.ImageLike = getKindIcon(item.kind as Kind);
     if (item.thumbnail) {
       icon = item.thumbnail.sm;
     } else if (item.data?.webpage?.favicon?.url) {
@@ -83,12 +83,7 @@ const apiFilter = async (searchQuery: SearchQuery): Promise<SearchResponse> => {
 };
 
 function Search() {
-  const emptyList: {
-    id: string;
-    name: string;
-    description: string;
-    icon: string;
-  }[] = [];
+  const emptyList: SearchResult[] = [];
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState<SearchQuery>({ text: "" });
   const [filteredList, filterList] = useState(emptyList);


### PR DESCRIPTION
## Description

Three changes:
1. allow assignging existing tags, and create new ones, when saving an item,
2. allow selecting location when saving an item,
3. fallback icons are based on item type.

## Screencast

![image](https://github.com/user-attachments/assets/b5cf9315-c92d-48ac-8ae1-4f415ccb5ddd)

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
